### PR TITLE
gofumpt: Run on whole repo

### DIFF
--- a/v2/cluster_test.go
+++ b/v2/cluster_test.go
@@ -203,10 +203,12 @@ func TestValidateOptions(t *testing.T) {
 		expOut      ClusterOptions
 		expError    bool
 	}{
-		{name: "empty cluster errors",
+		{
+			name:     "empty cluster errors",
 			expError: true,
 		},
-		{name: "default",
+		{
+			name:        "default",
 			clusterName: "test",
 			expOut: ClusterOptions{
 				MemberName:      "78fc2ffac2fd9401",
@@ -216,7 +218,8 @@ func TestValidateOptions(t *testing.T) {
 				memberKeyPrefix: "test/members/",
 			},
 		},
-		{name: "member name with dashes",
+		{
+			name:        "member name with dashes",
 			clusterName: "deploy",
 			in: ClusterOptions{
 				MemberName:    "pod-1",

--- a/v2/hash_test.go
+++ b/v2/hash_test.go
@@ -17,18 +17,23 @@ func TestConsistentHashRole(t *testing.T) {
 
 		expRank int32
 	}{
-		{name: "zero role count returns invalid role",
-			expRank: -1},
-		{name: "empty role can be ranked",
+		{
+			name:    "zero role count returns invalid role",
+			expRank: -1,
+		},
+		{
+			name:      "empty role can be ranked",
 			roleCount: 1,
 			expRank:   0,
 		},
-		{name: "'test' role is 1 when size is 10",
+		{
+			name:      "'test' role is 1 when size is 10",
 			role:      "test",
 			roleCount: 10,
 			expRank:   1,
 		},
-		{name: "'test' role is 1 when size is reduced to 5",
+		{
+			name:      "'test' role is 1 when size is reduced to 5",
 			role:      "test",
 			roleCount: 5,
 			expRank:   1,
@@ -74,7 +79,7 @@ func TestConsistentHash_EvenDistribution(t *testing.T) {
 	fiveCent := exp * 0.05
 
 	for rank, count := range roleRanks {
-		//diff := math.Abs(float64(count) - exp)
+		// diff := math.Abs(float64(count) - exp)
 		assert.InDelta(t, exp, count, fiveCent,
 			"rank %d has %d of %d roles", rank, count, roleCount,
 		)

--- a/v2/members_test.go
+++ b/v2/members_test.go
@@ -21,7 +21,8 @@ func TestGetMemberChanges(t *testing.T) {
 		expChanges memberChanges
 	}{
 		{name: "empty stays empty"},
-		{name: "old members stayed",
+		{
+			name:    "old members stayed",
 			members: map[string]time.Time{"alice": ts(101)},
 			last:    ranks{"alice": 0},
 			now:     ts(200),
@@ -29,14 +30,16 @@ func TestGetMemberChanges(t *testing.T) {
 				Remained: []string{"alice"},
 			},
 		},
-		{name: "new member added",
+		{
+			name:    "new member added",
 			members: map[string]time.Time{"alice": ts(100)},
 			now:     ts(200),
 			expChanges: memberChanges{
 				Added: []string{"alice"},
 			},
 		},
-		{name: "new member waits",
+		{
+			name:          "new member waits",
 			members:       map[string]time.Time{"alice": ts(200), "bob": ts(201)},
 			last:          map[string]int32{"alice": 0},
 			now:           ts(201),
@@ -46,7 +49,8 @@ func TestGetMemberChanges(t *testing.T) {
 				Waiting:  []string{"bob"},
 			},
 		},
-		{name: "new member replaces missing member",
+		{
+			name:    "new member replaces missing member",
 			members: map[string]time.Time{"bob": ts(1000)},
 			last:    map[string]int32{"alice": 0},
 			now:     ts(200),
@@ -54,7 +58,8 @@ func TestGetMemberChanges(t *testing.T) {
 				Replaced: map[string]string{"alice": "bob"},
 			},
 		},
-		{name: "bad last state ignored",
+		{
+			name:    "bad last state ignored",
 			members: map[string]time.Time{"alice": ts(100)},
 			last:    ranks{"alice": 100},
 			now:     ts(200),
@@ -62,7 +67,8 @@ func TestGetMemberChanges(t *testing.T) {
 				Remained: []string{"alice"},
 			},
 		},
-		{name: "new cluster add members regardless of wait",
+		{
+			name:          "new cluster add members regardless of wait",
 			members:       map[string]time.Time{"alice": ts(100), "bob": ts(101)},
 			now:           ts(100),
 			newMemberWait: time.Minute,
@@ -70,14 +76,16 @@ func TestGetMemberChanges(t *testing.T) {
 				Added: []string{"alice", "bob"},
 			},
 		},
-		{name: "new members, in order",
+		{
+			name:    "new members, in order",
 			members: map[string]time.Time{"alice": ts(102), "bob": ts(101)},
 			now:     ts(200),
 			expChanges: memberChanges{
 				Added: []string{"bob", "alice"},
 			},
 		},
-		{name: "new members get added after delay expired",
+		{
+			name:          "new members get added after delay expired",
 			members:       map[string]time.Time{"alice": ts(100), "bob": ts(200)},
 			last:          map[string]int32{"alice": 0},
 			now:           ts(201),
@@ -87,7 +95,8 @@ func TestGetMemberChanges(t *testing.T) {
 				Added:    []string{"bob"},
 			},
 		},
-		{name: "old members removed",
+		{
+			name:    "old members removed",
 			members: map[string]time.Time{"bob": ts(101)},
 			last:    ranks{"alice": 0, "bob": 1},
 			now:     ts(200),
@@ -96,7 +105,8 @@ func TestGetMemberChanges(t *testing.T) {
 				Removed:  []string{"alice"},
 			},
 		},
-		{name: "old members replaced by new",
+		{
+			name:    "old members replaced by new",
 			members: map[string]time.Time{"bob": ts(101), "carol": ts(102)},
 			last:    ranks{"alice": 0, "bob": 1},
 			now:     ts(200),
@@ -105,7 +115,8 @@ func TestGetMemberChanges(t *testing.T) {
 				Replaced: map[string]string{"alice": "carol"},
 			},
 		},
-		{name: "full shuffle",
+		{
+			name:    "full shuffle",
 			members: map[string]time.Time{"bob": ts(101), "carol": ts(102), "dave": ts(103)},
 			last:    ranks{"alice": 0, "bob": 1},
 			now:     ts(200),
@@ -140,19 +151,23 @@ func TestGetNewRanks(t *testing.T) {
 		expRanks ranks
 	}{
 		{name: "no changes to empty"},
-		{name: "no changes to existing",
+		{
+			name:     "no changes to existing",
 			last:     ranks{"alice": 0},
 			changes:  memberChanges{Remained: []string{"alice"}},
 			expRanks: ranks{"alice": 0},
 		},
-		{name: "empty changes results in empty ranks",
+		{
+			name: "empty changes results in empty ranks",
 			last: ranks{"alice": 0},
 		},
-		{name: "add new member",
+		{
+			name:     "add new member",
 			changes:  memberChanges{Added: []string{"alice"}},
 			expRanks: ranks{"alice": 0},
 		},
-		{name: "add new member with existing",
+		{
+			name: "add new member with existing",
 			changes: memberChanges{
 				Added:    []string{"alice"},
 				Remained: []string{"bob"},
@@ -160,14 +175,16 @@ func TestGetNewRanks(t *testing.T) {
 			last:     ranks{"bob": 0},
 			expRanks: ranks{"bob": 0, "alice": 1},
 		},
-		{name: "replace existing member",
+		{
+			name: "replace existing member",
 			changes: memberChanges{
 				Replaced: map[string]string{"alice": "bob"},
 			},
 			last:     ranks{"alice": 0},
 			expRanks: ranks{"bob": 0},
 		},
-		{name: "lots of changes",
+		{
+			name: "lots of changes",
 			changes: memberChanges{
 				Remained: []string{"alice"},
 				Removed:  []string{"bob"},
@@ -185,7 +202,8 @@ func TestGetNewRanks(t *testing.T) {
 				"dave":  2,
 			},
 		},
-		{name: "old members had big ranks",
+		{
+			name: "old members had big ranks",
 			changes: memberChanges{
 				Remained: []string{"alice"},
 				Replaced: map[string]string{"bob": "carol"},

--- a/v2/role.go
+++ b/v2/role.go
@@ -14,8 +14,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-type AssignRoleFunc func(role string, roleCount int32) int32
-type RoleNotify func(role string, locked bool)
+type (
+	AssignRoleFunc func(role string, roleCount int32) int32
+	RoleNotify     func(role string, locked bool)
+)
 
 type RolesOptions struct {
 	// Log is used for logging messages and errors on role management

--- a/v2/watch.go
+++ b/v2/watch.go
@@ -10,8 +10,10 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
-const etcdScanPage = 1000
-const monitorInterval = 5 * time.Minute
+const (
+	etcdScanPage    = 1000
+	monitorInterval = 5 * time.Minute
+)
 
 func knownLeases(ctx context.Context, cli *clientv3.Client) (map[clientv3.LeaseID]int64, error) {
 	leases, err := cli.Lease.Leases(ctx)


### PR DESCRIPTION
### Changed
- Run gofumpt on whole repo, so pre-commit hook won't change files unrelated to future MRs