### PR TITLE
ci: test latest Go only and bump go.mod to 1.26.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,10 +12,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        go: ['1.23', '1']
-
     services:
       etcd:
         image: quay.io/coreos/etcd:v3.6.5
@@ -32,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version: '1'
         id: go
 
       - name: Vet

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/rink/v2
 
-go 1.25
+go 1.26.0
 
 require (
 	github.com/dgryski/go-jump v0.0.0-20211018200510-ba001c3ffce0

--- a/role_test.go
+++ b/role_test.go
@@ -472,8 +472,7 @@ func TestRoles_RoleClashError(t *testing.T) {
 	_, err = createLock(ctx, sess2, ns, "clash", 0)
 	jtest.Assert(t, concurrency.ErrLocked, err)
 
-	var je *errors.JettisonError
-	require.True(t, errors.As(err, &je))
-	_, ok := je.GetKey("held_by_lease")
+	kvs := errors.GetKeyValues(err)
+	_, ok := kvs["held_by_lease"]
 	require.True(t, ok)
 }


### PR DESCRIPTION
Simplify the CI test matrix to only test with the latest Go (`'1'`), and bump the `go` directive in `go.mod` to `1.26.0`.

Testing multiple Go versions caused flaky failures whenever we bumped deps ahead of the oldest supported version. Since we don't commit to long-term compatibility with older Go releases, there's no value in the matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Updated Go toolchain requirement to version 1.26.0, establishing the new minimum supported Go version for development, building, and deployment of the project
- Restructured continuous integration workflow to run builds, tests, and vetting against a single Go version instead of a previously configured matrix covering multiple versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->